### PR TITLE
Add license header check/fix using spotless

### DIFF
--- a/formatter/license-header.txt
+++ b/formatter/license-header.txt
@@ -1,0 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -5,7 +5,7 @@ allprojects {
             // Normally this isn't necessary, but we have Java sources in
             // non-standard places
             target '**/*.java'
-
+            
             removeUnusedImports()
             eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()
@@ -22,5 +22,10 @@ allprojects {
                 paddedCell()
             }
         }
+        format("license", {
+            licenseHeaderFile("${rootProject.file("formatter/license-header.txt")}", "package ");
+            target("src/main/java/**/*.java")
+            targetExclude("**/netty4/*")
+        })
     }
 }

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -5,7 +5,7 @@ allprojects {
             // Normally this isn't necessary, but we have Java sources in
             // non-standard places
             target '**/*.java'
-            
+
             removeUnusedImports()
             eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
             trimTrailingWhitespace()

--- a/src/main/java/org/opensearch/sdk/ActionListener.java
+++ b/src/main/java/org/opensearch/sdk/ActionListener.java
@@ -5,7 +5,6 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-
 package org.opensearch.sdk;
 
 import org.opensearch.common.SuppressForbidden;

--- a/src/main/java/org/opensearch/sdk/ClusterSettingsResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/ClusterSettingsResponseHandler.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 package org.opensearch.sdk;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/sdk/ClusterStateResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/ClusterStateResponseHandler.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 package org.opensearch.sdk;
 
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -4,11 +4,7 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
-
 package org.opensearch.sdk;
 
 /**

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -4,11 +4,7 @@
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
- *
- * Modifications Copyright OpenSearch Contributors. See
- * GitHub history for details.
  */
-
 package org.opensearch.sdk;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/org/opensearch/sdk/LocalNodeResponseHandler.java
+++ b/src/main/java/org/opensearch/sdk/LocalNodeResponseHandler.java
@@ -1,3 +1,10 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 package org.opensearch.sdk;
 
 import org.apache.logging.log4j.LogManager;


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description
Uses the `licenseHeader` feature of spotless to apply a license header. 

WIthout proper headers, build will fail:
```
> Task :spotlessLicenseCheck FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':spotlessLicenseCheck'.
> The following files had format violations:
      src/main/java/org/opensearch/sdk/ActionListener.java
          @@ -5,7 +5,6 @@
           ·*·this·file·be·licensed·under·the·Apache-2.0·license·or·a
           ·*·compatible·open·source·license.
           ·*/
          -
           package·org.opensearch.sdk;
           
           import·org.opensearch.common.SuppressForbidden;
      src/main/java/org/opensearch/sdk/ClusterSettingsResponseHandler.java
          @@ -1,3 +1,10 @@
          +/*
          +·*·SPDX-License-Identifier:·Apache-2.0
          +·*

... snip ...

      src/main/java/org/opensearch/sdk/ExtensionsRunner.java
          @@ -4,11 +4,7 @@
           ·*·The·OpenSearch·Contributors·require·contributions·made·to
           ·*·this·file·be·licensed·under·the·Apache-2.0·license·or·a
      ... (9 more lines that didn't fit)
  Violations also present in:
      src/main/java/org/opensearch/sdk/LocalNodeResponseHandler.java
  Run './gradlew :spotlessApply' to fix these violations.
```
As suggested, `./gradlew spotlessApply` fixes the problem (and is how all the changed files were generated).

Netty4 package is excluded from this check (reviewers: should it be?)

### Issues Resolved
Fixes #50

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
