### PR TITLE
Added a new line linter

### DIFF
--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -1,0 +1,14 @@
+name: Code Hygiene
+
+on: [pull_request]
+
+jobs:
+  linelint:
+    runs-on: ubuntu-latest
+    name: Check if all files end in newline
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Linelint
+        uses: fernandrone/linelint@0.0.4

--- a/.linelint.yml
+++ b/.linelint.yml
@@ -1,0 +1,19 @@
+# 'true' will fix files
+autofix: true
+
+ignore:
+  - CONTRIBUTING.md
+  - DEVELOPER_GUIDE.md
+  - SECURITY.md
+  - formatter/license-header.txt
+  - settings.gradle
+  - src/main/resources/log4j2.xml
+
+rules:
+  # checks if file ends in a newline character
+  end-of-file:
+    # set to true to enable this rule
+    enable: true
+
+    # if true also checks if file ends in a single newline character
+    single-new-line: true

--- a/.linelint.yml
+++ b/.linelint.yml
@@ -6,7 +6,6 @@ ignore:
   - DEVELOPER_GUIDE.md
   - SECURITY.md
   - formatter/license-header.txt
-  - settings.gradle
   - src/main/resources/log4j2.xml
 
 rules:

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 rootProject.name = 'IndependentPlugin'
-


### PR DESCRIPTION
Signed-off-by: Owais Kazi <owaiskazi19@gmail.com>

### Description
Added a new-line linter to make sure all files end with a single newline. This is a POSIX standard, read more https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline. 

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk/issues/46

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
