### PR TITLE
Get Extension API during initialization

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionSettings.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionSettings.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.sdk;
 
+import java.util.List;
+
 /**
  * This class encapsulates the settings for an Extension.
  */
@@ -15,6 +17,7 @@ public class ExtensionSettings {
     private String extensionName;
     private String hostAddress;
     private String hostPort;
+    private List<String> api;
 
     /**
      * Placeholder field. Change the location to extension.yml file of the extension.
@@ -40,9 +43,20 @@ public class ExtensionSettings {
         return hostPort;
     }
 
-    @Override
-    public String toString() {
-        return "\nnodename: " + extensionName + "\nhostaddress: " + hostAddress + "\nhostPort: " + hostPort + "\n";
+    public List<String> getApi() {
+        return api;
     }
 
+    @Override
+    public String toString() {
+        return "ExtensionSettings {extensionName="
+            + extensionName
+            + ", hostAddress="
+            + hostAddress
+            + ", hostPort="
+            + hostPort
+            + ", api="
+            + api
+            + "}";
+    }
 }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -95,11 +95,11 @@ public class ExtensionsRunner {
      * Handles a plugin request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
      *
      * @param pluginRequest  The request to handle.
-     * @return A response to OpenSearch validating that this is an extension.
+     * @return A response to OpenSearch with the extension name and API.
      */
     PluginResponse handlePluginsRequest(PluginRequest pluginRequest) {
         logger.info("Registering Plugin Request received from OpenSearch");
-        PluginResponse pluginResponse = new PluginResponse(extensionSettings.getExtensionName());
+        PluginResponse pluginResponse = new PluginResponse(extensionSettings.getExtensionName(), extensionSettings.getApi());
         opensearchNode = pluginRequest.getSourceNode();
         setOpensearchNode(opensearchNode);
         return pluginResponse;

--- a/src/test/resources/extension.yml
+++ b/src/test/resources/extension.yml
@@ -1,3 +1,7 @@
 extensionName: extension
 hostAddress: 127.0.0.1
 hostPort: 4532
+api:
+  - API1
+  - API2
+  - API3


### PR DESCRIPTION
Signed-off-by: Daniel Widdis <widdis@gmail.com>

### Description

(This is a draft PR submitted for review/feedback of initial approach. Please wait until all sub-issues are complete before merging.)

Companion PR: https://github.com/opensearch-project/OpenSearch/pull/4056

Extensions will report their APIs to the ExtensionsOrchestrator during initialization. These APIs will be registered and mapped so that when Users submit API requests they can be forwarded to the appropriate extensions.

### Issues Resolved
Meta issue #64
 - [X] Fixes #68
 - [ ] Fixes #69
 - [ ] Fixes #70

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
