### PR TITLE
Rename to Extensions

### DIFF
--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -22,8 +22,8 @@ import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.PageCacheRecycler;
-import org.opensearch.discovery.PluginRequest;
-import org.opensearch.discovery.PluginResponse;
+import org.opensearch.discovery.InitializeExtensionsRequest;
+import org.opensearch.discovery.InitializeExtensionsResponse;
 import org.opensearch.extensions.ExtensionRequest;
 import org.opensearch.extensions.ExtensionsOrchestrator;
 import org.opensearch.extensions.ExtensionBooleanResponse;
@@ -104,12 +104,12 @@ public class ExtensionsRunner {
      * @param pluginRequest  The request to handle.
      * @return A response to OpenSearch validating that this is an extension.
      */
-    PluginResponse handlePluginsRequest(PluginRequest pluginRequest) {
+    InitializeExtensionsResponse handlePluginsRequest(InitializeExtensionsRequest initializeExtensionsRequest) {
         logger.info("Registering Plugin Request received from OpenSearch");
-        PluginResponse pluginResponse = new PluginResponse(extensionSettings.getExtensionName());
-        opensearchNode = pluginRequest.getSourceNode();
+        InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse("RealExtension");
+        opensearchNode = initializeExtensionsRequest.getSourceNode();
         setOpensearchNode(opensearchNode);
-        return pluginResponse;
+        return initializeExtensionsResponse;
     }
 
     /**
@@ -247,7 +247,7 @@ public class ExtensionsRunner {
             ThreadPool.Names.GENERIC,
             false,
             false,
-            PluginRequest::new,
+            InitializeExtensionsRequest::new,
             (request, channel, task) -> channel.sendResponse(handlePluginsRequest(request))
         );
 

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -99,14 +99,14 @@ public class ExtensionsRunner {
     }
 
     /**
-     * Handles a extensions request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
+     * Handles a extension request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
      *
      * @param extensionInitRequest  The request to handle.
      * @return A response to OpenSearch validating that this is an extension.
      */
     InitializeExtensionsResponse handleExtensionInitRequest(InitializeExtensionsRequest extensionInitRequest) {
         logger.info("Registering Extension Request received from OpenSearch");
-        InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse("RealExtension");
+        InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse(extensionSettings.getExtensionName());
         opensearchNode = extensionInitRequest.getSourceNode();
         setOpensearchNode(opensearchNode);
         return initializeExtensionsResponse;

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -101,16 +101,15 @@ public class ExtensionsRunner {
     /**
      * Handles a plugin request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
      *
-     * @param pluginRequest  The request to handle.
+     * @param extensionInitRequest  The request to handle.
      * @return A response to OpenSearch validating that this is an extension.
      */
-    InitializeExtensionsResponse handlePluginsRequest(InitializeExtensionsRequest initializeExtensionsRequest) {
+    InitializeExtensionsResponse handleExtensionInitRequest(InitializeExtensionsRequest extensionInitRequest) {
         logger.info("Registering Plugin Request received from OpenSearch");
         InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse("RealExtension");
-        opensearchNode = initializeExtensionsRequest.getSourceNode();
+        opensearchNode = extensionInitRequest.getSourceNode();
         setOpensearchNode(opensearchNode);
         return initializeExtensionsResponse;
-<<<<<<< HEAD
     }
 
     /**
@@ -129,12 +128,10 @@ public class ExtensionsRunner {
             default:
                 throw new Exception("Handler not present for the provided request");
         }
-=======
->>>>>>> issue #28
     }
 
     /**
-     * Handles a request for extension point indices from OpenSearch.  The {@link #handlePluginsRequest(PluginRequest)} method must have been called first to initialize the extension.
+     * Handles a request for extension point indices from OpenSearch.  The {@link #handleExtensionInitRequest(InitializeExtensionsRequest)} method must have been called first to initialize the extension.
      *
      * @param indicesModuleRequest  The request to handle.
      * @param transportService  The transport service communicating with OpenSearch.
@@ -144,14 +141,14 @@ public class ExtensionsRunner {
         logger.info("Registering Indices Module Request received from OpenSearch");
         IndicesModuleResponse indicesModuleResponse = new IndicesModuleResponse(true, true, true);
 
-        // handlePluginsRequest will set the opensearchNode while bootstraping of OpenSearch
+        // handleExtensionInitRequest will set the opensearchNode while bootstraping of OpenSearch
         DiscoveryNode opensearchNode = getOpensearchNode();
         transportService.connectToNode(opensearchNode);
         return indicesModuleResponse;
     }
 
     /**
-     * Handles a request for extension name from OpenSearch.  The {@link #handlePluginsRequest(PluginRequest)} method must have been called first to initialize the extension.
+     * Handles a request for extension name from OpenSearch.  The {@link #handleExtensionInitRequest(InitializeExtensionsRequest)} method must have been called first to initialize the extension.
      *
      * @param indicesModuleRequest  The request to handle.
      * @return A response acknowledging the request.
@@ -251,7 +248,7 @@ public class ExtensionsRunner {
             false,
             false,
             InitializeExtensionsRequest::new,
-            (request, channel, task) -> channel.sendResponse(handlePluginsRequest(request))
+            (request, channel, task) -> channel.sendResponse(handleExtensionInitRequest(request))
         );
 
         transportService.registerRequestHandler(

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -99,13 +99,13 @@ public class ExtensionsRunner {
     }
 
     /**
-     * Handles a plugin request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
+     * Handles a extensions request from OpenSearch.  This is the first request for the transport communication and will initialize the extension and will be a part of OpenSearch bootstrap.
      *
      * @param extensionInitRequest  The request to handle.
      * @return A response to OpenSearch validating that this is an extension.
      */
     InitializeExtensionsResponse handleExtensionInitRequest(InitializeExtensionsRequest extensionInitRequest) {
-        logger.info("Registering Plugin Request received from OpenSearch");
+        logger.info("Registering Extension Request received from OpenSearch");
         InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse("RealExtension");
         opensearchNode = extensionInitRequest.getSourceNode();
         setOpensearchNode(opensearchNode);

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -110,6 +110,7 @@ public class ExtensionsRunner {
         opensearchNode = initializeExtensionsRequest.getSourceNode();
         setOpensearchNode(opensearchNode);
         return initializeExtensionsResponse;
+<<<<<<< HEAD
     }
 
     /**
@@ -128,6 +129,8 @@ public class ExtensionsRunner {
             default:
                 throw new Exception("Handler not present for the provided request");
         }
+=======
+>>>>>>> issue #28
     }
 
     /**

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -98,7 +98,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
     }
 
     @Test
-    public void testHandlePluginsRequest() throws UnknownHostException {
+    public void testHandleExtensionInitRequest() throws UnknownHostException {
         DiscoveryNode sourceNode = new DiscoveryNode(
             "test_node",
             new TransportAddress(InetAddress.getByName("localhost"), 9876),
@@ -110,7 +110,7 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
         InitializeExtensionsResponse response = extensionsRunner.handleExtensionInitRequest(extensionInitRequest);
         assertEquals(response.getName(), "extension");
 
-        // Test if the source node is set after handlePluginRequest() is called during OpenSearch bootstrap
+        // Test if the source node is set after handleExtensionInitRequest()) is called during OpenSearch bootstrap
         assertEquals(extensionsRunner.getOpensearchNode(), sourceNode);
     }
 

--- a/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
+++ b/src/test/java/org/opensearch/sdk/TestExtensionsRunner.java
@@ -32,8 +32,8 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.io.stream.NamedWriteableRegistryResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
-import org.opensearch.discovery.PluginRequest;
-import org.opensearch.discovery.PluginResponse;
+import org.opensearch.discovery.InitializeExtensionsRequest;
+import org.opensearch.discovery.InitializeExtensionsResponse;
 import org.opensearch.extensions.OpenSearchRequest;
 import org.opensearch.extensions.ExtensionsOrchestrator.OpenSearchRequestType;
 import org.opensearch.sdk.handlers.ClusterSettingsResponseHandler;
@@ -106,8 +106,8 @@ public class TestExtensionsRunner extends OpenSearchTestCase {
             emptySet(),
             Version.CURRENT
         );
-        PluginRequest pluginRequest = new PluginRequest(sourceNode, null);
-        PluginResponse response = extensionsRunner.handlePluginsRequest(pluginRequest);
+        InitializeExtensionsRequest extensionInitRequest = new InitializeExtensionsRequest(sourceNode, null);
+        InitializeExtensionsResponse response = extensionsRunner.handleExtensionInitRequest(extensionInitRequest);
         assertEquals(response.getName(), "extension");
 
         // Test if the source node is set after handlePluginRequest() is called during OpenSearch bootstrap


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
Change the class (PluginRequest, PluginResponse) to (InitializeExtensionsRequest, InitializeExtensionsResponse), and the variable name related to class (PluginRequest, PluginResponse).
Equivalent PR on OpenSearch : https://github.com/opensearch-project/OpenSearch/pull/4063

### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk/issues/28

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
