### PR TITLE
issue # 49 Rename and possibly move static method for determining local ephemeral address

### DIFF
--- a/src/main/java/org/opensearch/sdk/ActionListener.java
+++ b/src/main/java/org/opensearch/sdk/ActionListener.java
@@ -32,7 +32,7 @@ public class ActionListener {
      * @throws UnknownHostException if the local host name could not be resolved into an address.
      */
     @SuppressForbidden(reason = "need local ephemeral port")
-    protected static InetSocketAddress createLocalEphemeralAddress() throws UnknownHostException {
+    private static InetSocketAddress createLocalEphemeralAddress() throws UnknownHostException {
         return new InetSocketAddress(InetAddress.getLocalHost(), 0);
     }
 

--- a/src/main/java/org/opensearch/sdk/ActionListener.java
+++ b/src/main/java/org/opensearch/sdk/ActionListener.java
@@ -32,7 +32,7 @@ public class ActionListener {
      * @throws UnknownHostException if the local host name could not be resolved into an address.
      */
     @SuppressForbidden(reason = "need local ephemeral port")
-    protected static InetSocketAddress getLocalEphemeral() throws UnknownHostException {
+    protected static InetSocketAddress createLocalEphemeralAddress() throws UnknownHostException {
         return new InetSocketAddress(InetAddress.getLocalHost(), 0);
     }
 
@@ -50,7 +50,7 @@ public class ActionListener {
             // for testing considerations, otherwise zero which is interpreted as an infinite timeout
             socket.setSoTimeout(timeout);
 
-            socket.bind(getLocalEphemeral(), 1);
+            socket.bind(createLocalEphemeralAddress(), 1);
             socket.setReuseAddress(true);
 
             Thread t = new Thread() {

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -248,11 +248,7 @@ public class ExtensionsRunner {
             false,
             false,
             InitializeExtensionsRequest::new,
-<<<<<<< HEAD
-            (request, channel, task) -> channel.sendResponse(handlePluginsRequest(request))
-=======
             (request, channel, task) -> channel.sendResponse(handleExtensionInitRequest(request))
->>>>>>> fd0f0708c14bf39c139b4cdea36b01839786a5ca
         );
 
         transportService.registerRequestHandler(

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -104,17 +104,10 @@ public class ExtensionsRunner {
      * @param extensionInitRequest  The request to handle.
      * @return A response to OpenSearch validating that this is an extension.
      */
-<<<<<<< HEAD
-    InitializeExtensionsResponse handlePluginsRequest(InitializeExtensionsRequest initializeExtensionsRequest) {
-        logger.info("Registering Plugin Request received from OpenSearch");
-        InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse("RealExtension");
-        opensearchNode = initializeExtensionsRequest.getSourceNode();
-=======
     InitializeExtensionsResponse handleExtensionInitRequest(InitializeExtensionsRequest extensionInitRequest) {
         logger.info("Registering Extension Request received from OpenSearch");
         InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse(extensionSettings.getExtensionName());
         opensearchNode = extensionInitRequest.getSourceNode();
->>>>>>> fd0f0708c14bf39c139b4cdea36b01839786a5ca
         setOpensearchNode(opensearchNode);
         return initializeExtensionsResponse;
     }

--- a/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
+++ b/src/main/java/org/opensearch/sdk/ExtensionsRunner.java
@@ -22,8 +22,8 @@ import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.PageCacheRecycler;
-import org.opensearch.discovery.PluginRequest;
-import org.opensearch.discovery.PluginResponse;
+import org.opensearch.discovery.InitializeExtensionsRequest;
+import org.opensearch.discovery.InitializeExtensionsResponse;
 import org.opensearch.extensions.ExtensionRequest;
 import org.opensearch.extensions.ExtensionsOrchestrator;
 import org.opensearch.extensions.ExtensionBooleanResponse;
@@ -104,12 +104,12 @@ public class ExtensionsRunner {
      * @param pluginRequest  The request to handle.
      * @return A response to OpenSearch validating that this is an extension.
      */
-    PluginResponse handlePluginsRequest(PluginRequest pluginRequest) {
+    InitializeExtensionsResponse handlePluginsRequest(InitializeExtensionsRequest initializeExtensionsRequest) {
         logger.info("Registering Plugin Request received from OpenSearch");
-        PluginResponse pluginResponse = new PluginResponse(extensionSettings.getExtensionName());
-        opensearchNode = pluginRequest.getSourceNode();
+        InitializeExtensionsResponse initializeExtensionsResponse = new InitializeExtensionsResponse("RealExtension");
+        opensearchNode = initializeExtensionsRequest.getSourceNode();
         setOpensearchNode(opensearchNode);
-        return pluginResponse;
+        return initializeExtensionsResponse;
     }
 
     /**
@@ -247,7 +247,7 @@ public class ExtensionsRunner {
             ThreadPool.Names.GENERIC,
             false,
             false,
-            PluginRequest::new,
+            InitializeExtensionsRequest::new,
             (request, channel, task) -> channel.sendResponse(handlePluginsRequest(request))
         );
 


### PR DESCRIPTION
Signed-off-by: mloufra <mloufra@amazon.com>

### Description
The ActionListener class has a protected static method getLocalEphemeral().

Subclasses can't access static method so protected access is inappropriate. Consider making private if only this class will use it. Consider refactoring to another class if it's going to be used by other classes
As it's not a field accessor, get*() is not the best name. Consider createLocalEphemeralAddress().


### Issues Resolved
https://github.com/opensearch-project/opensearch-sdk/issues/49

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
